### PR TITLE
Issue #74 - Rescan file list for prefix dirs on startup.

### DIFF
--- a/play.it-2/lib/libplayit2.sh
+++ b/play.it-2/lib/libplayit2.sh
@@ -2182,16 +2182,16 @@ write_bin() {
 			cat >> "$file" <<- 'EOF'
 			if [ ! -e "$PATH_PREFIX" ]; then
 			  mkdir --parents "$PATH_PREFIX"
-			  cp --force --recursive --symbolic-link --update "$PATH_GAME"/* "$PATH_PREFIX"
 			fi
+			cp --force --recursive --symbolic-link --update "$PATH_GAME"/* "$PATH_PREFIX"
 			if [ ! -e "$PATH_CONFIG" ]; then
 			  mkdir --parents "$PATH_CONFIG"
-			  init_userdir_files "$PATH_CONFIG" "$CONFIG_FILES"
 			fi
+			init_userdir_files "$PATH_CONFIG" "$CONFIG_FILES"
 			if [ ! -e "$PATH_DATA" ]; then
 			  mkdir --parents "$PATH_DATA"
-			  init_userdir_files "$PATH_DATA" "$DATA_FILES"
 			fi
+			init_userdir_files "$PATH_DATA" "$DATA_FILES"
 			init_prefix_files "$PATH_CONFIG" "$CONFIG_FILES"
 			init_prefix_files "$PATH_DATA" "$DATA_FILES"
 			init_prefix_dirs "$PATH_CONFIG" "$CONFIG_DIRS"

--- a/play.it-2/src/30_launchers.sh
+++ b/play.it-2/src/30_launchers.sh
@@ -238,16 +238,16 @@ write_bin() {
 			cat >> "$file" <<- 'EOF'
 			if [ ! -e "$PATH_PREFIX" ]; then
 			  mkdir --parents "$PATH_PREFIX"
-			  cp --force --recursive --symbolic-link --update "$PATH_GAME"/* "$PATH_PREFIX"
 			fi
+			cp --force --recursive --symbolic-link --update "$PATH_GAME"/* "$PATH_PREFIX"
 			if [ ! -e "$PATH_CONFIG" ]; then
 			  mkdir --parents "$PATH_CONFIG"
-			  init_userdir_files "$PATH_CONFIG" "$CONFIG_FILES"
 			fi
+			init_userdir_files "$PATH_CONFIG" "$CONFIG_FILES"
 			if [ ! -e "$PATH_DATA" ]; then
 			  mkdir --parents "$PATH_DATA"
-			  init_userdir_files "$PATH_DATA" "$DATA_FILES"
 			fi
+			init_userdir_files "$PATH_DATA" "$DATA_FILES"
 			init_prefix_files "$PATH_CONFIG" "$CONFIG_FILES"
 			init_prefix_files "$PATH_DATA" "$DATA_FILES"
 			init_prefix_dirs "$PATH_CONFIG" "$CONFIG_DIRS"


### PR DESCRIPTION
Tested with Surviving Mars + Surviving Mars Mystery Resupply Pack DLC. The prefix dir was initialized with only the Surviving Mars package installed. The DLC package was then added, and on the next start the DLC content was available in game and the symlinks correctly created in the prefix dir for the new content. Multiple starts did not cause any issues from the auto rescan/relink on startup (i.e. no duplicated files/symlinks/etc).